### PR TITLE
Include *all open* issues in the assigned_bugs.php emails

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,13 +5,15 @@
 This plugin can be used to send periodic email reminders to bug reporters,
 managers, and assignees.
 
-The files in the plugins/Reminder/scripts directory should be run directly,
+The files in the `plugins/Reminder/scripts` directory should be run directly,
 from the command line.
 
-bug_feedback_mail.php sends emails to reporters listing all bugs awaiting
-their feedback. bug_reminder_mail.php sends emails to assignees when bugs
-are approaching their due date. assigned_bugs.php sends emails to assignees
-listing all bugs assigned to them.
+1. `bug_feedback_mail.php` sends emails to reporters listing all bugs awaiting
+   their feedback.
+2. `bug_reminder_mail.php` sends emails to assignees when bugs are approaching
+   their due date.
+3. `assigned_bugs.php` sends emails to assignees listing all open bugs that are
+   assigned to them.
 
 This plugin is build upon version 1.2.x of mantis and should be installed as
 any other plugin. No Mantis scripts or tables are being altered.

--- a/scripts/assigned_bugs.php
+++ b/scripts/assigned_bugs.php
@@ -24,10 +24,11 @@ require_once( $t_core_path.'email_api.php' );
 # Build and bind query
 $t_bug_table = db_get_table( 'mantis_bug_table' );
 $t_user_table = db_get_table( 'mantis_user_table' );
+$t_resolved = config_get( 'bug_resolved_status_threshold' );
 $query = "SELECT DISTINCT b.id bug_id, b.summary, b.handler_id, u.realname, u.email "
 	." FROM $t_bug_table b JOIN $t_user_table u ON (b.handler_id = u.id) "
-	." WHERE status = ".ASSIGNED." ";
-$results = db_query_bound( $query );
+	." WHERE status != ".db_param();
+$results = db_query_bound( $query, array($t_resolved) );
 if ( ! $results) {
 	echo 'Query failed.';
 	exit( 1 );

--- a/scripts/assigned_bugs.php
+++ b/scripts/assigned_bugs.php
@@ -27,7 +27,7 @@ $t_user_table = db_get_table( 'mantis_user_table' );
 $t_resolved = config_get( 'bug_resolved_status_threshold' );
 $query = "SELECT DISTINCT b.id bug_id, b.summary, b.handler_id, u.realname, u.email "
 	." FROM $t_bug_table b JOIN $t_user_table u ON (b.handler_id = u.id) "
-	." WHERE status != ".db_param();
+	." WHERE status < ".db_param();
 $results = db_query_bound( $query, array($t_resolved) );
 if ( ! $results) {
 	echo 'Query failed.';


### PR DESCRIPTION
As per the documentation: "This script sends reminder emails to assignees of all open bugs."

This script has been only including those issues with a status of `ASSIGNED`, which is incorrect with respect to the documentation and no good if people are using custom statuses.

Also updated the README to better explain what this script is doing.