### PR TITLE
Remind only once

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -52,3 +52,6 @@ xxx		2013-03-07	samwilson	Moved to Github for easier collaboration.
 								Fixed paths in mailing scripts, so they can be called from anywhere.
 								Added assigned_bugs.php mailing script, to email assignees of open bugs.
 								Updated READMEs.
+
+xxx		06-06-2016	webmaniak	Added the unique reminder scripts which sends a reminder only once the
+								due date is x days/hours before the due date, where x is a parameter

--- a/README.txt
+++ b/README.txt
@@ -52,7 +52,7 @@ reminder_groupbody1	= "Please review the following issues";
 reminder_groupbody2	= "Please do not reply to this message";
 
 // perform for which project
-reminder_project_id = 0; means ALL
+reminder_project_id = 0; // 0 means ALL
 
 // how many days before Due date should we take into account
 reminder_days_treshold  = 2;
@@ -65,38 +65,38 @@ reminder_store_as_note = OFF;
 // only possible for handler
 
 // For which status to send reminders
-reminder_bug_status = ASSIGNED
+reminder_bug_status = array(ASSIGNED);
 
 // Ignore reminders for issues with no Due date set
-reminder_ignore_unset = ON
+reminder_ignore_unset = ON;
 
 // Ignore reminders for issues with Due dates in the past
-reminder_ign_past = ON
+reminder_ignore_past = ON;
 
 // only valid for the mail function, downloads will always have duedates that have gone by
 
 // Create overview per handler
-reminder_handler = ON
+reminder_handler = ON;
 
 // Group issues by Handler
-reminder_group_issues = ON
+reminder_group_issues = ON;
 
 // Group issues by project/handler
-reminder_group_project = OFF
+reminder_group_project = OFF;
 
 // Create overview per manager/project
-reminder_manager_overview = ON
+reminder_manager_overview = ON;
 //
-// access level for manager= 70
+// access level for manager = 70
 // this needs to be made flexible
 // we will only produce overview for those projects that have a separate manager
 //
 
 // Select project to receive Feedback mail
-reminder_feedback_project = 0; means ALL
+reminder_feedback_project = 0; // 0 means ALL
 
 // For which status to send feedbackreminders
-reminder_bug_status = FEEDBACK
+reminder_bug_status = array(FEEDBACK);
 
 
 ********************************************************************************
@@ -108,8 +108,10 @@ After this, bug_reminder_mail can be used via cron like this:
 
 or via command line interface
 */1440 *   *   *   * /usr/local/bin/php /path/to/mantis/plugins/Reminder/scripts/bug_reminder_mail.php
+This line would send out a reminder every day until the due date.
 
-This line would send out a reminder every day.
+You can also decide to run the script every day at 7a.m. and send a reminder only if it's near the due date (see parameter reminder_days_treshold for nb of days/hours):
+0 7 * * * /usr/local/bin/php /path/to/mantis/plugins/Reminder/scripts/bug_reminder_unique_mail.php
 
 You also can use a scheduled task under windows by calling a batch-file like:
 
@@ -136,9 +138,12 @@ http://www.YourMantisHome.com/plugins/Reminder/scripts/bug_due_overview2.php?day
 If you do not apply parameters, the script will default to the above.
 
 In the script directory you will also find a script called
-bug_reminder_mail_test.php This script which you should call from within the
+bug_reminder_mail_test.php. This script which you should call from within the
 browser (once logged on) will provide useful feedback if things are not
 working as expected. In case of a blank screen, all is processed normally.
+
+You can also use the test script named bug_reminder_unique_mail_test.php to test
+the unique reminder feature.
 
 For option Days/Hours, the script will fetch the plugin definition.
 

--- a/README.txt
+++ b/README.txt
@@ -12,11 +12,13 @@ from the command line.
    their feedback.
 2. `bug_reminder_mail.php` sends emails to assignees when bugs are approaching
    their due date.
-3. `assigned_bugs.php` sends emails to assignees listing all open bugs that are
+3. `bug_reminder_unique_mail.php` do the same as script n°2 but only when the
+   due date is the exact planned day (see parameter reminder_days_treshold)
+4. `assigned_bugs.php` sends emails to assignees listing all open bugs that are
    assigned to them.
 
-This plugin is build upon version 1.2.x of mantis and should be installed as
-any other plugin. No Mantis scripts or tables are being altered.
+This plugin is build upon version 1.2.x of mantis and should be installed like
+any other plugin. No Mantis scripts or tables are being create/altered.
 
 
 ********************************************************************************
@@ -25,13 +27,13 @@ any other plugin. No Mantis scripts or tables are being altered.
 
 Like any other plugin.
 After copying to your webserver :
-- Start mantis ad administrator
+- Start mantis as administrator
 - Select manage
 - Select manage Plugins
-- Select Install behind Reminder 1.10
-- Once installed, click on the plugin-name for further configuration.
+- Select Install near "Reminder 1.xx" (where 1.xx is the version no)
+- Once installed, click on the plugin name for further configuration.
 
-For version 1.2.1 make sure to have this statement in confg_inc.php:
+For version 1.2.x make sure to have this statement in confg_inc.php:
 $g_path          = 'http://path to your mantis installation/';
 
 
@@ -103,14 +105,16 @@ reminder_bug_status = array(FEEDBACK);
 * Automatically generating mail                                                *
 ********************************************************************************
 
-After this, bug_reminder_mail can be used via cron like this:
+The bug_reminder_mail script can be called via cron like this (using Lynx):
 */1440 *   *   *   * lynx --dump http://mantis.homepage.com/plugins/Reminder/scripts/bug_reminder_mail.php
 
-or via command line interface
+or via command line interface (recommanded):
 */1440 *   *   *   * /usr/local/bin/php /path/to/mantis/plugins/Reminder/scripts/bug_reminder_mail.php
+
 This line would send out a reminder every day until the due date.
 
-You can also decide to run the script every day at 7a.m. and send a reminder only if it's near the due date (see parameter reminder_days_treshold for nb of days/hours):
+You can also decide to run the script every day at 7a.m. and send a reminder only
+if it's near the due date (see parameter reminder_days_treshold for nb of days/hours):
 0 7 * * * /usr/local/bin/php /path/to/mantis/plugins/Reminder/scripts/bug_reminder_unique_mail.php
 
 You also can use a scheduled task under windows by calling a batch-file like:
@@ -119,7 +123,6 @@ REM *** this batch is running as a scheduled task under the ... Account ***
 g:
 cd \inetpub\wwwroot\mantis
 php.exe plugins/Reminder/scripts/bug_reminder_mail.php
-
 
 One can also schedule a job to prompt reporters to respond because their
 issue has status Feedback. In that case replace bug_reminder_mail.php with

--- a/scripts/bug_reminder_unique_mail.php
+++ b/scripts/bug_reminder_unique_mail.php
@@ -1,0 +1,242 @@
+<?php
+# Make sure this script doesn't run via the webserver
+if( php_sapi_name() != 'cli' ) {
+	echo "It is not allowed to run this script through the webserver.\n";
+	exit( 1 );
+}
+# This page sends an E-mail if a due date is getting near
+# includes all due_dates not met
+require_once( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . DIRECTORY_SEPARATOR . 'core.php' );
+$t_login	= config_get( 'plugin_Reminder_reminder_login' );
+$ok=auth_attempt_script_login( $t_login );
+$t_core_path = config_get( 'core_path' );
+require_once( $t_core_path.'bug_api.php' );
+require_once( $t_core_path.'email_api.php' );
+require_once( $t_core_path.'bugnote_api.php' );
+require_once( $t_core_path.'category_api.php' );
+require_once( $t_core_path.'helper_api.php' );
+
+$allok= true ;
+$t_bug_table	= db_get_table( 'mantis_bug_table' );
+$t_bug_text_table = db_get_table( 'mantis_bug_text_table' );
+$t_man_table	= db_get_table( 'mantis_project_user_list_table' );
+
+$t_rem_project	= config_get( 'plugin_Reminder_reminder_project_id' );
+$t_rem_days		= config_get( 'plugin_Reminder_reminder_days_treshold' );
+$t_rem_status	= config_get( 'plugin_Reminder_reminder_bug_status' );
+$t_rem_body		= config_get( 'plugin_Reminder_reminder_mail_subject' );
+$t_rem_store	= config_get( 'plugin_Reminder_reminder_store_as_note' );
+$t_rem_ignore	= config_get( 'plugin_Reminder_reminder_ignore_unset' );
+$t_rem_ign_past	= config_get( 'plugin_Reminder_reminder_ignore_past' );
+$t_rem_handler 	= config_get( 'plugin_Reminder_reminder_handler' );
+$t_rem_group1	= config_get( 'plugin_Reminder_reminder_group_issues' );
+$t_rem_group2	= config_get( 'plugin_Reminder_reminder_group_project' );
+$t_rem_manager	= config_get( 'plugin_Reminder_reminder_manager_overview' );
+$t_rem_subject	= config_get( 'plugin_Reminder_reminder_group_subject' );
+$t_rem_body1	= config_get( 'plugin_Reminder_reminder_group_body1' );
+$t_rem_body2	= config_get( 'plugin_Reminder_reminder_group_body2' );
+
+$t_rem_hours	= config_get('plugin_Reminder_reminder_hours');
+if (ON != $t_rem_hours){
+	$multiply=24;
+} else{
+	$multiply=1;
+}
+
+//
+// access level for manager= 70
+// this needs to be made flexible
+// we will only produce overview for those projects that have a separate manager
+//
+$baseline = time(true)+ ($t_rem_days*$multiply*60*60);
+$baselinedate = date('d-m-Y',$baseline);
+
+if ( ON == $t_rem_handler ) {
+	$query = "select bugs.id, bugs.handler_id, bugs.project_id, bugs.priority, bugs.category_id, bugs.status, bugs.severity, bugs.summary from $t_bug_table bugs JOIN $t_bug_text_table text ON (bugs.bug_text_id = text.id) where status in (".implode(",", $t_rem_status).") and DATE_FORMAT(FROM_UNIXTIME(due_date), '%d-%m-%Y') = '$baselinedate' and handler_id<>0 ";
+	if ( ON != $t_rem_ign_past ) {
+		if ( ON == $t_rem_ignore ) {
+			$query .=" and due_date>1" ;
+		}
+	}
+	if ( $t_rem_project>0 ) {
+		$query .=" and project_id=$t_rem_project" ;
+	}
+	if ( ON == $t_rem_group1 ) {
+		$query .=" order by handler_id" ;
+	}else{
+		if ( ON == $t_rem_group2 ) {
+			$query .=" order by project_id,handler_id" ;
+		}
+	}
+	$results = db_query_bound( $query );
+	$resnum=db_num_rows($results);
+	if ( OFF == $t_rem_group1 ) {
+		if ($results) {
+			while ($row1 = db_fetch_array($results)) {
+				$id 		= $row1['id'];
+				$handler	= $row1['handler_id'];
+				$list = string_get_bug_view_url_with_fqdn( $id, $handler2 );
+				$body  = $t_rem_body1. " \n\n";
+				$body .= $list. " \n\n";
+				$body .= $t_rem_body2;
+				$result = email_group_reminder( $handler, $body );
+				# Add reminder as bugnote if store reminders option is ON.
+				if ( ON == $t_rem_store ) {
+					$t_attr = '|'.$handler2.'|';
+					bugnote_add( $id, $t_rem_body, 0, config_get( 'default_reminder_view_status' ) == VS_PRIVATE, REMINDER, $t_attr, NULL, FALSE );
+				}
+			}
+		}
+	} else {
+		if ($results){
+			$start = true ;
+			$list= "";
+			// first group and store reminder per issue
+			while ($row1 = db_fetch_array($results)) {
+				$id 		= $row1['id'];
+				$handler	= $row1['handler_id'];
+				$project	= $row1['project_id'];
+				if ($start){
+					$handler2 = $handler ;
+					$start = false ;
+				}
+				if ($handler==$handler2){
+					$list .= formatBugEntry($row1);
+					# Add reminder as bugnote if store reminders option is ON.
+					if ( ON == $t_rem_store ) {
+						$t_attr = '|'.$handler2.'|';
+						bugnote_add( $id, $t_rem_body, 0, config_get( 'default_reminder_view_status' ) == VS_PRIVATE, REMINDER, $t_attr, NULL, FALSE );
+					}
+				} else {
+					// now send the grouped email
+					$body  = $t_rem_body1. " \n\n";
+					$body .= $list. " \n\n";
+					$body .= $t_rem_body2;
+					$result = email_group_reminder( $handler2, $body);
+					$handler2 = $handler ;
+					$list = formatBugEntry($row1);
+					# Add reminder as bugnote if store reminders option is ON.
+					if ( ON == $t_rem_store ) {
+						$t_attr = '|'.$handler2.'|';
+						bugnote_add( $id, $t_rem_body, 0, config_get( 'default_reminder_view_status' ) == VS_PRIVATE, REMINDER, $t_attr, NULL, FALSE );
+					}
+				}
+			}
+			// handle last one
+			if ($resnum>0){
+				// now send the grouped email
+				$body  = $t_rem_body1. " \n\n";
+				$body .= $list. " \n\n";
+				$body .= $t_rem_body2;
+				$result = email_group_reminder( $handler2, $body);
+
+			}
+			//
+		}
+	}
+}
+
+if ( ON == $t_rem_manager ) {
+	// select relevant issues in combination with an assigned manager to the project
+	$query  = "select id,handler_id,user_id from $t_bug_table,$t_man_table where status in (".implode(",", $t_rem_status).") and DATE_FORMAT(FROM_UNIXTIME(due_date), '%d-%m-%Y') = '$baselinedate' ";
+	if ( ON != $t_rem_ign_past ) {
+		if ( ON == $t_rem_ignore ) {
+			$query .=" and due_date>1" ;
+		}
+	}
+	if ( $t_rem_project>0 ) {
+		$query .=" and $t_bug_table.project_id=$t_rem_project" ;
+	}
+	$query .=" and $t_bug_table.project_id=$t_man_table.project_id and $t_man_table.access_level=70" ;
+	$query .=" order by $t_man_table.project_id,$t_man_table.user_id" ;
+	$results = db_query_bound( $query );
+	$resnum=db_num_rows($results);
+	if ($results){
+		$start = true ;
+		$list= "";
+		// first group and store reminder per issue
+		while ($row1 = db_fetch_array($results)) {
+			$id 		= $row1['id'];
+			$handler	= $row1['handler_id'];
+			$manager	= $row1['user_id'];
+			if ($start){
+				$man2 = $manager ;
+				$start = false ;
+			}
+			if ($manager==$man2){
+				$list .=" \n\n";
+				$list .= string_get_bug_view_url_with_fqdn( $id, $man2 );
+			} else {
+				// now send the grouped email
+				$body  = $t_rem_body1. " \n\n";
+				$body .= $list. " \n\n";
+				$body .= $t_rem_body2;
+				$result = email_group_reminder( $man2, $body);
+				$man2 = $manager ;
+				$list= string_get_bug_view_url_with_fqdn( $id, $man2 );
+				$list .= " \n\n";
+			}
+		}
+		// handle last one
+		if ($resnum>0){
+			// now send the grouped email
+			$body  = $t_rem_body1. " \n\n";
+			$body .= $list. " \n\n";
+			$body .= $t_rem_body2;
+			$result = email_group_reminder( $man2, $body);
+
+		}
+		//
+	}
+}
+if (php_sapi_name() !== 'cli'){
+	echo config_get( 'plugin_Reminder_reminder_finished' );
+}
+
+# Send Grouped reminder
+function email_group_reminder( $p_user_id, $issues ) {
+	$t_username = user_get_field( $p_user_id, 'username' );
+	$t_email = user_get_email( $p_user_id );
+	$t_subject = config_get( 'plugin_Reminder_reminder_group_subject' );
+	$t_message = $issues ;
+	if( !is_blank( $t_email ) ) {
+		email_store( $t_email, $t_subject, $t_message );
+		if( OFF == config_get( 'email_send_using_cronjob' ) ) {
+			email_send_all();
+		}
+	}
+}
+
+function formatBugEntry($data){
+	lang_push( user_pref_get_language( $data['handler_id'] ) );
+
+	$p_visible_bug_data = $data;
+	$p_visible_bug_data['email_project'] = project_get_name( $data['project_id']);
+	$p_visible_bug_data['email_category'] = category_get_name($data['category_id']);
+
+	$t_email_separator1 = config_get( 'email_separator1' );
+	$t_email_separator2 = config_get( 'email_separator2' );
+
+	$p_visible_bug_data['email_bug'] = $data['id'];
+	$p_visible_bug_data['email_status'] = get_enum_element( 'status', $p_visible_bug_data['status'], $data['handler_id'], $data['project_id'] );
+	$p_visible_bug_data['email_severity'] = get_enum_element( 'severity', $p_visible_bug_data['severity'] );
+	$p_visible_bug_data['email_priority'] = get_enum_element( 'priority', $p_visible_bug_data['priority'] );
+	$p_visible_bug_data['email_reproducibility'] = get_enum_element( 'reproducibility', $p_visible_bug_data['reproducibility'] );
+	$p_visible_bug_data['email_summary'] = $data['summary'];
+
+	$t_message = $t_email_separator1 . " \n";
+	$t_message .= string_get_bug_view_url_with_fqdn( $data['id'], $data['handler_id'] ) . " \n";
+	$t_message .= $t_email_separator1 . " \n";
+
+	$t_message .= email_format_attribute( $p_visible_bug_data, 'email_project' );
+	$t_message .= email_format_attribute( $p_visible_bug_data, 'email_bug' );
+	$t_message .= email_format_attribute( $p_visible_bug_data, 'email_category' );
+	$t_message .= email_format_attribute( $p_visible_bug_data, 'email_priority' );
+	$t_message .= email_format_attribute( $p_visible_bug_data, 'email_status' );
+	$t_message .= $t_email_separator1 . " \n";
+
+	$t_message .= email_format_attribute( $p_visible_bug_data, 'email_summary' );
+	$t_message .= $t_email_separator1 . " \n\n\n";
+
+	return $t_message;
+}

--- a/scripts/bug_reminder_unique_mail_test.php
+++ b/scripts/bug_reminder_unique_mail_test.php
@@ -1,0 +1,257 @@
+<?php
+# This page tests sending an E-mail if a due date is getting near
+# No real email is sent not are notes crreated for the various issues
+require_once( '../../../core.php' );
+$t_login	= config_get( 'plugin_Reminder_reminder_login' );
+$ok=auth_attempt_script_login( $t_login );
+$t_core_path = config_get( 'core_path' );
+require_once( $t_core_path.'bug_api.php' );
+require_once( $t_core_path.'email_api.php' );
+require_once( $t_core_path.'bugnote_api.php' );
+
+$t_bug_table	= db_get_table( 'mantis_bug_table' );
+$t_man_table	= db_get_table( 'mantis_project_user_list_table' );
+
+$t_rem_project	= config_get( 'plugin_Reminder_reminder_project_id' );
+$t_rem_days		= config_get( 'plugin_Reminder_reminder_days_treshold' );
+$t_rem_status	= config_get( 'plugin_Reminder_reminder_bug_status' );
+$t_rem_body		= config_get( 'plugin_Reminder_reminder_mail_subject' );
+$t_rem_store	= config_get( 'plugin_Reminder_reminder_store_as_note' );
+$t_rem_ignore	= config_get( 'plugin_Reminder_reminder_ignore_unset' );
+$t_rem_ign_past	= config_get( 'plugin_Reminder_reminder_ignore_past' );
+$t_rem_handler	= config_get( 'plugin_Reminder_reminder_handler' );
+$t_rem_group1	= config_get( 'plugin_Reminder_reminder_group_issues' );
+$t_rem_group2	= config_get( 'plugin_Reminder_reminder_group_project' );
+$t_rem_manager	= config_get( 'plugin_Reminder_reminder_manager_overview' );
+$t_rem_subject	= config_get( 'plugin_Reminder_reminder_group_subject' );
+$t_rem_body1	= config_get( 'plugin_Reminder_reminder_group_body1' );
+$t_rem_body2	= config_get( 'plugin_Reminder_reminder_group_body2' );
+
+$t_rem_hours	= config_get('plugin_Reminder_reminder_hours');
+if (ON != $t_rem_hours){
+	$multiply=24;
+} else{
+	$multiply=1;
+}
+//
+// access level for manager= 70
+// this needs to be made flexible
+// we will only produce overview for those projects that have a separate manager
+//
+$baseline	= time(true)+ ($t_rem_days*$multiply*60*60);
+$baselinedate = date('d-m-Y',$baseline);
+
+echo "Path setting retrieved : ".config_get('path');
+echo "<br>";
+
+if ( ON == $t_rem_handler ) {
+	echo 'Query-handler being executed' ;
+	echo '<br>';
+	$query = "select id,handler_id,project_id from $t_bug_table where status in (".implode(",", $t_rem_status).") and DATE_FORMAT(FROM_UNIXTIME(due_date), '%d-%m-%Y') = '$baselinedate' and handler_id>0 ";
+	if ( ON != $t_rem_ign_past ) {
+		if ( ON == $t_rem_ignore ) {
+			$query .=" and due_date>1" ;
+		}
+	}
+	if ( $t_rem_project>0 ) {
+		$query .=" and project_id=$t_rem_project" ;
+	}
+	if ( ON == $t_rem_group1 ) {
+		$query .=" order by handler_id" ;
+	}else{
+		if ( ON == $t_rem_group2 ) {
+			$query .=" order by project_id,handler_id" ;
+		}
+	}
+	echo $query;
+	echo "<br>"  ;
+	$results = db_query_bound( $query );
+	$resnum=db_num_rows($results);
+	echo $resnum;
+	echo "<br>"  ;
+	if ( OFF == $t_rem_group1 ) {
+		if ($results) {
+			while ($row1 = db_fetch_array($results)) {
+				$id 		= $row1['id'];
+				$handler	= $row1['handler_id'];
+				echo $id;
+				echo '*';
+				echo $handler;
+				echo "<br>";
+				$list = string_get_bug_view_url_with_fqdn( $id, $handler2 );
+				$body  = $t_rem_body1;
+				$body .= "<br>";
+				$body .= $list;
+				$body .= "<br>";
+				$body .= $t_rem_body2;
+				$result = email_group_reminder( $handler, $body );
+				# Add reminder as bugnote if store reminders option is ON.
+				if ( ON == $t_rem_store ) {
+					$t_attr = '|'.$handler2.'|';
+//					bugnote_add( $id, $t_rem_body, 0, config_get( 'default_reminder_view_status' ) == VS_PRIVATE, REMINDER, $t_attr, NULL, FALSE );
+				}
+			}
+		} else {
+			echo 'Query-handler had no results'.$query ;
+			echo '<br>';
+		}
+	} else {
+		if ($results){
+			$start = true ;
+			$list= "";
+			// first group and store reminder per issue
+			while ($row1 = db_fetch_array($results)) {
+				$id 		= $row1['id'];
+				$handler	= $row1['handler_id'];
+				$project	= $row1['project_id'];
+				echo $id;
+				echo '*';
+				echo $handler;
+				echo '*';
+				echo $project;
+				echo "<br>";
+				if ($start){
+					$handler2 = $handler ;
+					$start = false ;
+				}
+				if ($handler==$handler2){
+					$list .="<br>";
+					$list .= string_get_bug_view_url_with_fqdn( $id, $handler2 );
+					# Add reminder as bugnote if store reminders option is ON.
+					if ( ON == $t_rem_store ) {
+						$t_attr = '|'.$handler2.'|';
+//						bugnote_add( $id, $t_rem_body, 0, config_get( 'default_reminder_view_status' ) == VS_PRIVATE, REMINDER, $t_attr, NULL, FALSE );
+					}
+				} else {
+					// now send the grouped email
+					$body  = $t_rem_body1;
+					$body .= "<br>";
+					$body .= $list;
+					$body .= "<br>";
+					$body .= $t_rem_body2;
+					$result = email_group_reminder( $handler2, $body);
+					$handler2 = $handler ;
+					$list ="<br>";
+					$list= string_get_bug_view_url_with_fqdn( $id, $handler2 );
+					# Add reminder as bugnote if store reminders option is ON.
+					if ( ON == $t_rem_store ) {
+						$t_attr = '|'.$handler2.'|';
+//						bugnote_add( $id, $t_rem_body, 0, config_get( 'default_reminder_view_status' ) == VS_PRIVATE, REMINDER, $t_attr, NULL, FALSE );
+					}
+				}
+			}
+			// handle last one
+			if ($resnum>0){
+				// now send the grouped email
+				$body  = $t_rem_body1;
+				$body .= "<br>";
+				$body .= $list;
+				$body .= "<br>";
+				$body .= $t_rem_body2;
+				$result = email_group_reminder( $handler2, $body);
+
+			} else{
+				echo 'Query-Handler had no results '.$query ;
+				echo '<br>';
+			}
+			//
+		}else {
+			echo 'Query-handler had no results '.$query ;
+			echo '<br>';
+		}
+	}
+}
+
+if ( ON == $t_rem_manager ) {
+	echo 'Query-Manager being executed' ;
+	echo '<br>';
+	// select relevant issues in combination with an assigned manager to the project
+	$query  = "select id,handler_id,user_id from $t_bug_table,$t_man_table where status in (".implode(",", $t_rem_status).") and DATE_FORMAT(FROM_UNIXTIME(due_date), '%d-%m-%Y') = '$baselinedate' ";
+	if ( ON != $t_rem_ign_past ) {
+		if ( ON == $t_rem_ignore ) {
+			$query .=" and due_date>1" ;
+		}
+	}
+	if ( $t_rem_project>0 ) {
+		$query .=" and $t_bug_table.project_id=$t_rem_project" ;
+	}
+	$query .=" and $t_bug_table.project_id=$t_man_table.project_id and $t_man_table.access_level=70" ;
+	$query .=" order by $t_man_table.project_id,$t_man_table.user_id" ;
+	echo $query;
+	echo "<br>"  ;
+	$results = db_query_bound( $query );
+	$resnum=db_num_rows($results);
+	echo $resnum;
+	echo "<br>"  ;
+	if ($results){
+		$start = true ;
+		$list= "";
+		// first group and store reminder per issue
+		while ($row1 = db_fetch_array($results)) {
+				$id 		= $row1['id'];
+				$handler	= $row1['handler_id'];
+				$manager	= $row1['user_id'];
+			echo $id;
+			echo '*';
+			echo $handler;
+			echo '*';
+			echo $manager;
+			echo "<br>";
+			if ($start){
+				$man2 = $manager ;
+				$start = false ;
+			}
+			if ($manager==$man2){
+				$list .=" \n\n";
+				$list .= string_get_bug_view_url_with_fqdn( $id, $man2 );
+			} else {
+				// now send the grouped email
+				$body  = $t_rem_body1. " \n\n";
+				$body .= $list. " \n\n";
+				$body .= $t_rem_body2;
+				$result = email_group_reminder( $man2, $body);
+				$man2 = $manager ;
+				$list= string_get_bug_view_url_with_fqdn( $id, $man2 );
+				$list .= " \n\n";
+			}
+		}
+		// handle last one
+		if ($resnum>0){
+			// now send the grouped email
+			$body  = $t_rem_body1. " \n\n";
+			$body .= $list. " \n\n";
+			$body .= $t_rem_body2;
+			$result = email_group_reminder( $man2, $body);
+
+		}else{
+				echo 'Query-Manager had no results '.$query ;
+				echo '<br>';
+			}
+		//
+	} else {
+		echo 'Query-Manager had no results '.$query ;
+		echo '<br>';
+	}
+}
+echo '<br><br><br>';
+echo 'Finished Reminder Test ';
+
+# Send Grouped reminder
+function email_group_reminder( $p_user_id, $issues ) {
+	$t_username = user_get_field( $p_user_id, 'username' );
+	$t_email = user_get_email( $p_user_id );
+	$t_subject = config_get( 'plugin_Reminder_reminder_group_subject' );
+	$t_message = $issues ;
+	if( !is_blank( $t_email ) ) {
+		echo $t_email;
+		echo '**';
+		echo $t_subject;
+		echo '<br>';
+		echo $t_message;
+		echo '<br>';
+//		email_store( $t_email, $t_subject, $t_message );
+		if( OFF == config_get( 'email_send_using_cronjob' ) ) {
+//			email_send_all();
+		}
+	}
+}


### PR DESCRIPTION
Hi everybody!

A few days ago I installed the plugin on my Mantis installation and it worked fine after some fine-tuning (mostly what the README.txt file says), but I noticed that a reminder was sent everyday and that was really annoying for some users.

I decided then to make some changes to the scripts and thought that could be interesting for others. So there we are, I'm pull requesting a script which sends a **unique reminder** the specified amount of time before the due date.

As I'm pretty new to GitHub, I hope I've done everything right. ;)
