### PR TITLE
Fix Reminder E-Mail only contains last issue link after Update to 2.30

### DIFF
--- a/scripts/bug_reminder_mail.php
+++ b/scripts/bug_reminder_mail.php
@@ -183,21 +183,22 @@ if ( ON == $t_rem_manager ) {
 			if ($manager==$man2){
 				$list .=" \n\n";
 				if ( ON == $t_details ) {
-					$list = formatBugEntry($row1);
+					$list .= formatBugEntry($row1);
 				} else {
-					$list = string_get_bug_view_url_with_fqdn( $id, $man2 );
+					$list .= string_get_bug_view_url_with_fqdn( $id, $man2 );
 				}
 			} else {
 				// now send the grouped email
+				$list .=" \n\n";
 				$body  = $t_rem_body1. " \n\n";
 				$body .= $list. " \n\n";
 				$body .= $t_rem_body2;
 				$result = email_group_reminder( $man2, $body);
 				$man2 = $manager ;
 				if ( ON == $t_details ) {
-					$list = formatBugEntry($row1);
+					$list .= formatBugEntry($row1);
 				} else {
-					$list = string_get_bug_view_url_with_fqdn( $id, $man2 );
+					$list .= string_get_bug_view_url_with_fqdn( $id, $man2 );
 				}
 				$list .= " \n\n";
 			}


### PR DESCRIPTION
## Summary

Fixes a regression introduced in v2.30 where grouped reminder emails only contained the last issue link instead of all matching issues.

The issue list was overwritten while building the grouped email body. This PR changes the affected assignments back to append operations so that all issue entries are preserved in the generated reminder email.

## Problem

After updating to v2.30, reminder emails sent by the plugin may miss multiple issue links. Although `bug_reminder_mail_test.php` can still show the expected output, the actually sent grouped reminder emails only include the last issue for each recipient/group.

## Fix

- Append issue entries to `$list` instead of overwriting the existing list.
- Preserve all matching issues before sending the grouped reminder email.
- Fix grouped reminder output for both detailed entries and plain issue URLs.

## Related issue

Fixes #18